### PR TITLE
mamba-env-build: Store locked env file and set yaml env var

### DIFF
--- a/actions/mamba-env-build/action.yml
+++ b/actions/mamba-env-build/action.yml
@@ -189,6 +189,12 @@ runs:
         echo "Copying environment file and checksum to ${INSTALL_FOLDER}"
         cp $YML_FILE ${INSTALL_FOLDER}/${YML_FILE_NAME}
         cp $YML_FILE.sha256sum ${INSTALL_FOLDER}/${YML_FILE_NAME}.sha256sum
+        # Add variable to env path
+        echo >> ${MODULE_FOLDER}/${VERSION}.lua
+        echo "setenv(\"CONDA_ENVIRONMENT_YML\", \"${INSTALL_FOLDER}/${YML_FILE_NAME}\")" >> ${MODULE_FOLDER}/${VERSION}.lua
+        # Store locked environment files, too
+        mamba env export --no-builds -f ${INSTALL_FOLDER}/${YML_FILE_NAME}.lock
+        mamba env export -f ${INSTALL_FOLDER}/${YML_FILE_NAME}.build-lock
         echo "::endgroup::"
 
       done


### PR DESCRIPTION
- Having a locked environment file means that one can see the exact versions inside of an environment without loading it and running `conda env export`.  Several times this would have been convenient for my support of others.

- Second, add a modulefile env var which points to the build environment file.  This doesn't have a practical use, but someone going `module show NAME` can easily see that it's there, and thus is more likely to find it and understand what the module is about.  (It would also save me some time)

- None of these have been tested yet, so they need a careful read and fixing.