### PR TITLE
 mamba-env-build: Store locked env file and set yaml env var (fixed)

### DIFF
--- a/actions/mamba-env-build/action.yml
+++ b/actions/mamba-env-build/action.yml
@@ -147,6 +147,11 @@ runs:
 
           micromamba create -y -f $YML_FILE -p ${INSTALL_FOLDER}
 
+          echo "Exporting realized env file to ${INSTALL_FOLDER}"
+
+          micromamba env export --no-build -p ${INSTALL_FOLDER} > ${INSTALL_FOLDER}/${YML_FILE_NAME}.lock
+          micromamba env export -p ${INSTALL_FOLDER} > ${INSTALL_FOLDER}/${YML_FILE_NAME}.build-lock
+
           echo "Cleaning up pip wheel cache"
           rm -rf ~/.cache/pip/wheels
         fi
@@ -179,6 +184,8 @@ runs:
 
       prepend_path("PATH", "${INSTALL_FOLDER}/bin")
       setenv("CONDA_PREFIX", "${INSTALL_FOLDER}")
+
+      setenv("CONDA_ENVIRONMENT_YML", "${INSTALL_FOLDER}/${YML_FILE_NAME}")
       EOF
         fi
 
@@ -189,12 +196,6 @@ runs:
         echo "Copying environment file and checksum to ${INSTALL_FOLDER}"
         cp $YML_FILE ${INSTALL_FOLDER}/${YML_FILE_NAME}
         cp $YML_FILE.sha256sum ${INSTALL_FOLDER}/${YML_FILE_NAME}.sha256sum
-        # Add variable to env path
-        echo >> ${MODULE_FOLDER}/${VERSION}.lua
-        echo "setenv(\"CONDA_ENVIRONMENT_YML\", \"${INSTALL_FOLDER}/${YML_FILE_NAME}\")" >> ${MODULE_FOLDER}/${VERSION}.lua
-        # Store locked environment files, too
-        mamba env export --no-builds -f ${INSTALL_FOLDER}/${YML_FILE_NAME}.lock
-        mamba env export -f ${INSTALL_FOLDER}/${YML_FILE_NAME}.build-lock
         echo "::endgroup::"
 
       done

--- a/actions/mamba-env-build/action.yml
+++ b/actions/mamba-env-build/action.yml
@@ -189,6 +189,12 @@ runs:
         echo "Copying environment file and checksum to ${INSTALL_FOLDER}"
         cp $YML_FILE ${INSTALL_FOLDER}/${YML_FILE_NAME}
         cp $YML_FILE.sha256sum ${INSTALL_FOLDER}/${YML_FILE_NAME}.sha256sum
+        # Add variable to env path
+        echo >> ${MODULE_FOLDER}/${VERSION}.lua
+        echo "setenv(\"CONDA_ENVIRONMENT_YML\", \"${INSTALL_FOLDER}/${YML_FILE_NAME}\")" >> ${MODULE_FOLDER}/${VERSION}.lua
+        # Store locked environment files, too
+        mamba env export --no-builds -f ${INSTALL_FOLDER}/${YML_FILE_NAME}.lock
+        mamba env export -f ${INSTALL_FOLDER}/${YML_FILE_NAME}.build-lock
         echo "::endgroup::"
 
       done


### PR DESCRIPTION
This fixes problems in PR: #1

- Fixed export commands to use micromamba
- Moved export commands to be done after installation
- Moved module modifications before module syntax check
- Added CONDA_ENVIRONMENT_YML to default modules, not custom ones
